### PR TITLE
set stac extension schema href to main

### DIFF
--- a/current/cbca/benefit-mapbox/benefit-mapbox-scenarios-RCP45-SSP1.json
+++ b/current/cbca/benefit-mapbox/benefit-mapbox-scenarios-RCP45-SSP1.json
@@ -108,7 +108,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "cbca"
 }

--- a/current/cbca/benefit-mapbox/benefit-mapbox-scenarios-RCP85-SSP5.json
+++ b/current/cbca/benefit-mapbox/benefit-mapbox-scenarios-RCP85-SSP5.json
@@ -108,7 +108,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "cbca"
 }

--- a/current/cbca/cbr-mapbox/cbr-mapbox-scenarios-RCP45-SSP1.json
+++ b/current/cbca/cbr-mapbox/cbr-mapbox-scenarios-RCP45-SSP1.json
@@ -108,7 +108,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "cbca"
 }

--- a/current/cbca/cbr-mapbox/cbr-mapbox-scenarios-RCP85-SSP5.json
+++ b/current/cbca/cbr-mapbox/cbr-mapbox-scenarios-RCP85-SSP5.json
@@ -108,7 +108,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "cbca"
 }

--- a/current/cbca/cost-mapbox/cost-mapbox-scenarios-RCP45-SSP1.json
+++ b/current/cbca/cost-mapbox/cost-mapbox-scenarios-RCP45-SSP1.json
@@ -108,7 +108,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "cbca"
 }

--- a/current/cbca/cost-mapbox/cost-mapbox-scenarios-RCP85-SSP5.json
+++ b/current/cbca/cost-mapbox/cost-mapbox-scenarios-RCP85-SSP5.json
@@ -108,7 +108,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "cbca"
 }

--- a/current/cbca/eb-mapbox/eb-mapbox-scenarios-RCP45-SSP1.json
+++ b/current/cbca/eb-mapbox/eb-mapbox-scenarios-RCP45-SSP1.json
@@ -108,7 +108,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "cbca"
 }

--- a/current/cbca/eb-mapbox/eb-mapbox-scenarios-RCP85-SSP5.json
+++ b/current/cbca/eb-mapbox/eb-mapbox-scenarios-RCP85-SSP5.json
@@ -108,7 +108,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "cbca"
 }

--- a/current/cfr/collection.json
+++ b/current/cfr/collection.json
@@ -28,7 +28,7 @@
         }
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json",
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json",
         "https://stac-extensions.github.io/datacube/v2.0.0/schema.json"
     ],
     "deltares:units": "m",

--- a/current/cfr/ead-mapbox/ead-mapbox-scenarios-RCP4.5-SSP1-time-2000.json
+++ b/current/cfr/ead-mapbox/ead-mapbox-scenarios-RCP4.5-SSP1-time-2000.json
@@ -109,7 +109,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "cfr"
 }

--- a/current/cfr/ead-mapbox/ead-mapbox-scenarios-RCP4.5-SSP1-time-2050.json
+++ b/current/cfr/ead-mapbox/ead-mapbox-scenarios-RCP4.5-SSP1-time-2050.json
@@ -109,7 +109,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "cfr"
 }

--- a/current/cfr/ead-mapbox/ead-mapbox-scenarios-RCP4.5-SSP1-time-2100.json
+++ b/current/cfr/ead-mapbox/ead-mapbox-scenarios-RCP4.5-SSP1-time-2100.json
@@ -109,7 +109,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "cfr"
 }

--- a/current/cfr/ead-mapbox/ead-mapbox-scenarios-RCP8.5-SSP3-time-2000.json
+++ b/current/cfr/ead-mapbox/ead-mapbox-scenarios-RCP8.5-SSP3-time-2000.json
@@ -109,7 +109,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "cfr"
 }

--- a/current/cfr/ead-mapbox/ead-mapbox-scenarios-RCP8.5-SSP3-time-2050.json
+++ b/current/cfr/ead-mapbox/ead-mapbox-scenarios-RCP8.5-SSP3-time-2050.json
@@ -109,7 +109,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "cfr"
 }

--- a/current/cfr/ead-mapbox/ead-mapbox-scenarios-RCP8.5-SSP3-time-2100.json
+++ b/current/cfr/ead-mapbox/ead-mapbox-scenarios-RCP8.5-SSP3-time-2100.json
@@ -109,7 +109,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "cfr"
 }

--- a/current/cfr/ead-mapbox/ead-mapbox-scenarios-RCP8.5-SSP5-time-2000.json
+++ b/current/cfr/ead-mapbox/ead-mapbox-scenarios-RCP8.5-SSP5-time-2000.json
@@ -109,7 +109,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "cfr"
 }

--- a/current/cfr/ead-mapbox/ead-mapbox-scenarios-RCP8.5-SSP5-time-2050.json
+++ b/current/cfr/ead-mapbox/ead-mapbox-scenarios-RCP8.5-SSP5-time-2050.json
@@ -109,7 +109,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "cfr"
 }

--- a/current/cfr/ead-mapbox/ead-mapbox-scenarios-RCP8.5-SSP5-time-2100.json
+++ b/current/cfr/ead-mapbox/ead-mapbox-scenarios-RCP8.5-SSP5-time-2100.json
@@ -109,7 +109,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "cfr"
 }

--- a/current/cfr/ead_gdp-mapbox/ead_gdp-mapbox-scenarios-RCP4.5-SSP1-time-2000.json
+++ b/current/cfr/ead_gdp-mapbox/ead_gdp-mapbox-scenarios-RCP4.5-SSP1-time-2000.json
@@ -109,7 +109,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "cfr"
 }

--- a/current/cfr/ead_gdp-mapbox/ead_gdp-mapbox-scenarios-RCP4.5-SSP1-time-2050.json
+++ b/current/cfr/ead_gdp-mapbox/ead_gdp-mapbox-scenarios-RCP4.5-SSP1-time-2050.json
@@ -109,7 +109,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "cfr"
 }

--- a/current/cfr/ead_gdp-mapbox/ead_gdp-mapbox-scenarios-RCP4.5-SSP1-time-2100.json
+++ b/current/cfr/ead_gdp-mapbox/ead_gdp-mapbox-scenarios-RCP4.5-SSP1-time-2100.json
@@ -109,7 +109,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "cfr"
 }

--- a/current/cfr/ead_gdp-mapbox/ead_gdp-mapbox-scenarios-RCP8.5-SSP3-time-2000.json
+++ b/current/cfr/ead_gdp-mapbox/ead_gdp-mapbox-scenarios-RCP8.5-SSP3-time-2000.json
@@ -109,7 +109,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "cfr"
 }

--- a/current/cfr/ead_gdp-mapbox/ead_gdp-mapbox-scenarios-RCP8.5-SSP3-time-2050.json
+++ b/current/cfr/ead_gdp-mapbox/ead_gdp-mapbox-scenarios-RCP8.5-SSP3-time-2050.json
@@ -109,7 +109,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "cfr"
 }

--- a/current/cfr/ead_gdp-mapbox/ead_gdp-mapbox-scenarios-RCP8.5-SSP3-time-2100.json
+++ b/current/cfr/ead_gdp-mapbox/ead_gdp-mapbox-scenarios-RCP8.5-SSP3-time-2100.json
@@ -109,7 +109,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "cfr"
 }

--- a/current/cfr/ead_gdp-mapbox/ead_gdp-mapbox-scenarios-RCP8.5-SSP5-time-2000.json
+++ b/current/cfr/ead_gdp-mapbox/ead_gdp-mapbox-scenarios-RCP8.5-SSP5-time-2000.json
@@ -109,7 +109,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "cfr"
 }

--- a/current/cfr/ead_gdp-mapbox/ead_gdp-mapbox-scenarios-RCP8.5-SSP5-time-2050.json
+++ b/current/cfr/ead_gdp-mapbox/ead_gdp-mapbox-scenarios-RCP8.5-SSP5-time-2050.json
@@ -109,7 +109,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "cfr"
 }

--- a/current/cfr/ead_gdp-mapbox/ead_gdp-mapbox-scenarios-RCP8.5-SSP5-time-2100.json
+++ b/current/cfr/ead_gdp-mapbox/ead_gdp-mapbox-scenarios-RCP8.5-SSP5-time-2100.json
@@ -109,7 +109,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "cfr"
 }

--- a/current/cfr/eapa-mapbox/eapa-mapbox-scenarios-RCP4.5-SSP1-time-2000.json
+++ b/current/cfr/eapa-mapbox/eapa-mapbox-scenarios-RCP4.5-SSP1-time-2000.json
@@ -109,7 +109,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "cfr"
 }

--- a/current/cfr/eapa-mapbox/eapa-mapbox-scenarios-RCP4.5-SSP1-time-2050.json
+++ b/current/cfr/eapa-mapbox/eapa-mapbox-scenarios-RCP4.5-SSP1-time-2050.json
@@ -109,7 +109,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "cfr"
 }

--- a/current/cfr/eapa-mapbox/eapa-mapbox-scenarios-RCP4.5-SSP1-time-2100.json
+++ b/current/cfr/eapa-mapbox/eapa-mapbox-scenarios-RCP4.5-SSP1-time-2100.json
@@ -109,7 +109,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "cfr"
 }

--- a/current/cfr/eapa-mapbox/eapa-mapbox-scenarios-RCP8.5-SSP3-time-2000.json
+++ b/current/cfr/eapa-mapbox/eapa-mapbox-scenarios-RCP8.5-SSP3-time-2000.json
@@ -109,7 +109,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "cfr"
 }

--- a/current/cfr/eapa-mapbox/eapa-mapbox-scenarios-RCP8.5-SSP3-time-2050.json
+++ b/current/cfr/eapa-mapbox/eapa-mapbox-scenarios-RCP8.5-SSP3-time-2050.json
@@ -109,7 +109,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "cfr"
 }

--- a/current/cfr/eapa-mapbox/eapa-mapbox-scenarios-RCP8.5-SSP3-time-2100.json
+++ b/current/cfr/eapa-mapbox/eapa-mapbox-scenarios-RCP8.5-SSP3-time-2100.json
@@ -109,7 +109,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "cfr"
 }

--- a/current/cfr/eapa-mapbox/eapa-mapbox-scenarios-RCP8.5-SSP5-time-2000.json
+++ b/current/cfr/eapa-mapbox/eapa-mapbox-scenarios-RCP8.5-SSP5-time-2000.json
@@ -109,7 +109,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "cfr"
 }

--- a/current/cfr/eapa-mapbox/eapa-mapbox-scenarios-RCP8.5-SSP5-time-2050.json
+++ b/current/cfr/eapa-mapbox/eapa-mapbox-scenarios-RCP8.5-SSP5-time-2050.json
@@ -109,7 +109,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "cfr"
 }

--- a/current/cfr/eapa-mapbox/eapa-mapbox-scenarios-RCP8.5-SSP5-time-2100.json
+++ b/current/cfr/eapa-mapbox/eapa-mapbox-scenarios-RCP8.5-SSP5-time-2100.json
@@ -109,7 +109,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "cfr"
 }

--- a/current/cisi/collection.json
+++ b/current/cisi/collection.json
@@ -58,7 +58,7 @@
         }
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json",
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json",
         "https://stac-extensions.github.io/datacube/v2.0.0/schema.json"
     ],
     "deltares:units": "-",

--- a/current/cm/collection.json
+++ b/current/cm/collection.json
@@ -333,7 +333,7 @@
         }
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json",
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json",
         "https://stac-extensions.github.io/datacube/v2.0.0/schema.json"
     ],
     "deltares:units": "-",

--- a/current/eesl/collection.json
+++ b/current/eesl/collection.json
@@ -370,7 +370,7 @@
         }
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json",
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json",
         "https://stac-extensions.github.io/datacube/v2.0.0/schema.json"
     ],
     "deltares:units": "m",

--- a/current/eesl/eewl-mapbox/eewl-mapbox-scenarios-RCP45-rp-10.0.json
+++ b/current/eesl/eewl-mapbox/eewl-mapbox-scenarios-RCP45-rp-10.0.json
@@ -111,7 +111,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "eesl"
 }

--- a/current/eesl/eewl-mapbox/eewl-mapbox-scenarios-RCP45-rp-100.0.json
+++ b/current/eesl/eewl-mapbox/eewl-mapbox-scenarios-RCP45-rp-100.0.json
@@ -111,7 +111,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "eesl"
 }

--- a/current/eesl/eewl-mapbox/eewl-mapbox-scenarios-RCP45-rp-1000.0.json
+++ b/current/eesl/eewl-mapbox/eewl-mapbox-scenarios-RCP45-rp-1000.0.json
@@ -111,7 +111,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "eesl"
 }

--- a/current/eesl/eewl-mapbox/eewl-mapbox-scenarios-RCP45-rp-20.0.json
+++ b/current/eesl/eewl-mapbox/eewl-mapbox-scenarios-RCP45-rp-20.0.json
@@ -111,7 +111,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "eesl"
 }

--- a/current/eesl/eewl-mapbox/eewl-mapbox-scenarios-RCP45-rp-200.0.json
+++ b/current/eesl/eewl-mapbox/eewl-mapbox-scenarios-RCP45-rp-200.0.json
@@ -111,7 +111,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "eesl"
 }

--- a/current/eesl/eewl-mapbox/eewl-mapbox-scenarios-RCP45-rp-5.0.json
+++ b/current/eesl/eewl-mapbox/eewl-mapbox-scenarios-RCP45-rp-5.0.json
@@ -111,7 +111,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "eesl"
 }

--- a/current/eesl/eewl-mapbox/eewl-mapbox-scenarios-RCP45-rp-50.0.json
+++ b/current/eesl/eewl-mapbox/eewl-mapbox-scenarios-RCP45-rp-50.0.json
@@ -111,7 +111,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "eesl"
 }

--- a/current/eesl/eewl-mapbox/eewl-mapbox-scenarios-RCP45-rp-500.0.json
+++ b/current/eesl/eewl-mapbox/eewl-mapbox-scenarios-RCP45-rp-500.0.json
@@ -111,7 +111,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "eesl"
 }

--- a/current/eesl/eewl-mapbox/eewl-mapbox-scenarios-RCP85-rp-10.0.json
+++ b/current/eesl/eewl-mapbox/eewl-mapbox-scenarios-RCP85-rp-10.0.json
@@ -111,7 +111,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "eesl"
 }

--- a/current/eesl/eewl-mapbox/eewl-mapbox-scenarios-RCP85-rp-100.0.json
+++ b/current/eesl/eewl-mapbox/eewl-mapbox-scenarios-RCP85-rp-100.0.json
@@ -111,7 +111,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "eesl"
 }

--- a/current/eesl/eewl-mapbox/eewl-mapbox-scenarios-RCP85-rp-1000.0.json
+++ b/current/eesl/eewl-mapbox/eewl-mapbox-scenarios-RCP85-rp-1000.0.json
@@ -111,7 +111,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "eesl"
 }

--- a/current/eesl/eewl-mapbox/eewl-mapbox-scenarios-RCP85-rp-20.0.json
+++ b/current/eesl/eewl-mapbox/eewl-mapbox-scenarios-RCP85-rp-20.0.json
@@ -111,7 +111,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "eesl"
 }

--- a/current/eesl/eewl-mapbox/eewl-mapbox-scenarios-RCP85-rp-200.0.json
+++ b/current/eesl/eewl-mapbox/eewl-mapbox-scenarios-RCP85-rp-200.0.json
@@ -111,7 +111,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "eesl"
 }

--- a/current/eesl/eewl-mapbox/eewl-mapbox-scenarios-RCP85-rp-5.0.json
+++ b/current/eesl/eewl-mapbox/eewl-mapbox-scenarios-RCP85-rp-5.0.json
@@ -111,7 +111,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "eesl"
 }

--- a/current/eesl/eewl-mapbox/eewl-mapbox-scenarios-RCP85-rp-50.0.json
+++ b/current/eesl/eewl-mapbox/eewl-mapbox-scenarios-RCP85-rp-50.0.json
@@ -111,7 +111,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "eesl"
 }

--- a/current/eesl/eewl-mapbox/eewl-mapbox-scenarios-RCP85-rp-500.0.json
+++ b/current/eesl/eewl-mapbox/eewl-mapbox-scenarios-RCP85-rp-500.0.json
@@ -111,7 +111,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "eesl"
 }

--- a/current/eesl/esl-mapbox/esl-mapbox-scenarios-RCP45-rp-10.0.json
+++ b/current/eesl/esl-mapbox/esl-mapbox-scenarios-RCP45-rp-10.0.json
@@ -111,7 +111,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "eesl"
 }

--- a/current/eesl/esl-mapbox/esl-mapbox-scenarios-RCP45-rp-100.0.json
+++ b/current/eesl/esl-mapbox/esl-mapbox-scenarios-RCP45-rp-100.0.json
@@ -111,7 +111,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "eesl"
 }

--- a/current/eesl/esl-mapbox/esl-mapbox-scenarios-RCP45-rp-1000.0.json
+++ b/current/eesl/esl-mapbox/esl-mapbox-scenarios-RCP45-rp-1000.0.json
@@ -111,7 +111,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "eesl"
 }

--- a/current/eesl/esl-mapbox/esl-mapbox-scenarios-RCP45-rp-20.0.json
+++ b/current/eesl/esl-mapbox/esl-mapbox-scenarios-RCP45-rp-20.0.json
@@ -111,7 +111,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "eesl"
 }

--- a/current/eesl/esl-mapbox/esl-mapbox-scenarios-RCP45-rp-200.0.json
+++ b/current/eesl/esl-mapbox/esl-mapbox-scenarios-RCP45-rp-200.0.json
@@ -111,7 +111,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "eesl"
 }

--- a/current/eesl/esl-mapbox/esl-mapbox-scenarios-RCP45-rp-5.0.json
+++ b/current/eesl/esl-mapbox/esl-mapbox-scenarios-RCP45-rp-5.0.json
@@ -111,7 +111,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "eesl"
 }

--- a/current/eesl/esl-mapbox/esl-mapbox-scenarios-RCP45-rp-50.0.json
+++ b/current/eesl/esl-mapbox/esl-mapbox-scenarios-RCP45-rp-50.0.json
@@ -111,7 +111,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "eesl"
 }

--- a/current/eesl/esl-mapbox/esl-mapbox-scenarios-RCP45-rp-500.0.json
+++ b/current/eesl/esl-mapbox/esl-mapbox-scenarios-RCP45-rp-500.0.json
@@ -111,7 +111,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "eesl"
 }

--- a/current/eesl/esl-mapbox/esl-mapbox-scenarios-RCP85-rp-10.0.json
+++ b/current/eesl/esl-mapbox/esl-mapbox-scenarios-RCP85-rp-10.0.json
@@ -111,7 +111,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "eesl"
 }

--- a/current/eesl/esl-mapbox/esl-mapbox-scenarios-RCP85-rp-100.0.json
+++ b/current/eesl/esl-mapbox/esl-mapbox-scenarios-RCP85-rp-100.0.json
@@ -111,7 +111,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "eesl"
 }

--- a/current/eesl/esl-mapbox/esl-mapbox-scenarios-RCP85-rp-1000.0.json
+++ b/current/eesl/esl-mapbox/esl-mapbox-scenarios-RCP85-rp-1000.0.json
@@ -111,7 +111,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "eesl"
 }

--- a/current/eesl/esl-mapbox/esl-mapbox-scenarios-RCP85-rp-20.0.json
+++ b/current/eesl/esl-mapbox/esl-mapbox-scenarios-RCP85-rp-20.0.json
@@ -111,7 +111,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "eesl"
 }

--- a/current/eesl/esl-mapbox/esl-mapbox-scenarios-RCP85-rp-200.0.json
+++ b/current/eesl/esl-mapbox/esl-mapbox-scenarios-RCP85-rp-200.0.json
@@ -111,7 +111,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "eesl"
 }

--- a/current/eesl/esl-mapbox/esl-mapbox-scenarios-RCP85-rp-5.0.json
+++ b/current/eesl/esl-mapbox/esl-mapbox-scenarios-RCP85-rp-5.0.json
@@ -111,7 +111,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "eesl"
 }

--- a/current/eesl/esl-mapbox/esl-mapbox-scenarios-RCP85-rp-50.0.json
+++ b/current/eesl/esl-mapbox/esl-mapbox-scenarios-RCP85-rp-50.0.json
@@ -111,7 +111,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "eesl"
 }

--- a/current/eesl/esl-mapbox/esl-mapbox-scenarios-RCP85-rp-500.0.json
+++ b/current/eesl/esl-mapbox/esl-mapbox-scenarios-RCP85-rp-500.0.json
@@ -111,7 +111,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "eesl"
 }

--- a/current/sc/collection.json
+++ b/current/sc/collection.json
@@ -144,7 +144,7 @@
         }
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json",
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json",
         "https://stac-extensions.github.io/datacube/v2.0.0/schema.json"
     ],
     "deltares:units": "m",

--- a/current/sc/sc-mapbox/sc-mapbox-ensemble-1-scenarios-RCP45.json
+++ b/current/sc/sc-mapbox/sc-mapbox-ensemble-1-scenarios-RCP45.json
@@ -109,7 +109,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "sc"
 }

--- a/current/sc/sc-mapbox/sc-mapbox-ensemble-1-scenarios-RCP85.json
+++ b/current/sc/sc-mapbox/sc-mapbox-ensemble-1-scenarios-RCP85.json
@@ -109,7 +109,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "sc"
 }

--- a/current/sc/sc-mapbox/sc-mapbox-ensemble-17-scenarios-RCP45.json
+++ b/current/sc/sc-mapbox/sc-mapbox-ensemble-17-scenarios-RCP45.json
@@ -109,7 +109,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "sc"
 }

--- a/current/sc/sc-mapbox/sc-mapbox-ensemble-17-scenarios-RCP85.json
+++ b/current/sc/sc-mapbox/sc-mapbox-ensemble-17-scenarios-RCP85.json
@@ -109,7 +109,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "sc"
 }

--- a/current/sc/sc-mapbox/sc-mapbox-ensemble-5-scenarios-RCP45.json
+++ b/current/sc/sc-mapbox/sc-mapbox-ensemble-5-scenarios-RCP45.json
@@ -109,7 +109,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "sc"
 }

--- a/current/sc/sc-mapbox/sc-mapbox-ensemble-5-scenarios-RCP85.json
+++ b/current/sc/sc-mapbox/sc-mapbox-ensemble-5-scenarios-RCP85.json
@@ -109,7 +109,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "sc"
 }

--- a/current/sc/sc-mapbox/sc-mapbox-ensemble-50-scenarios-RCP45.json
+++ b/current/sc/sc-mapbox/sc-mapbox-ensemble-50-scenarios-RCP45.json
@@ -109,7 +109,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "sc"
 }

--- a/current/sc/sc-mapbox/sc-mapbox-ensemble-50-scenarios-RCP85.json
+++ b/current/sc/sc-mapbox/sc-mapbox-ensemble-50-scenarios-RCP85.json
@@ -109,7 +109,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "sc"
 }

--- a/current/sc/sc-mapbox/sc-mapbox-ensemble-83-scenarios-RCP45.json
+++ b/current/sc/sc-mapbox/sc-mapbox-ensemble-83-scenarios-RCP45.json
@@ -109,7 +109,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "sc"
 }

--- a/current/sc/sc-mapbox/sc-mapbox-ensemble-83-scenarios-RCP85.json
+++ b/current/sc/sc-mapbox/sc-mapbox-ensemble-83-scenarios-RCP85.json
@@ -109,7 +109,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "sc"
 }

--- a/current/sc/sc-mapbox/sc-mapbox-ensemble-95-scenarios-RCP45.json
+++ b/current/sc/sc-mapbox/sc-mapbox-ensemble-95-scenarios-RCP45.json
@@ -109,7 +109,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "sc"
 }

--- a/current/sc/sc-mapbox/sc-mapbox-ensemble-95-scenarios-RCP85.json
+++ b/current/sc/sc-mapbox/sc-mapbox-ensemble-95-scenarios-RCP85.json
@@ -109,7 +109,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "sc"
 }

--- a/current/sc/sc-mapbox/sc-mapbox-ensemble-99-scenarios-RCP45.json
+++ b/current/sc/sc-mapbox/sc-mapbox-ensemble-99-scenarios-RCP45.json
@@ -109,7 +109,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "sc"
 }

--- a/current/sc/sc-mapbox/sc-mapbox-ensemble-99-scenarios-RCP85.json
+++ b/current/sc/sc-mapbox/sc-mapbox-ensemble-99-scenarios-RCP85.json
@@ -109,7 +109,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "sc"
 }

--- a/current/slp5/collection.json
+++ b/current/slp5/collection.json
@@ -4248,7 +4248,7 @@
         }
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "deltares:units": "m",
     "deltares:plotSeries": "scenarios",

--- a/current/slp6/collection.json
+++ b/current/slp6/collection.json
@@ -22488,7 +22488,7 @@
         }
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "deltares:units": "mm",
     "deltares:plotSeries": "scenarios",

--- a/current/smd/collection.json
+++ b/current/smd/collection.json
@@ -18,7 +18,7 @@
         }
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json",
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json",
         "https://stac-extensions.github.io/datacube/v2.0.0/schema.json"
     ],
     "deltares:units": "m",

--- a/current/ssl/collection.json
+++ b/current/ssl/collection.json
@@ -234,7 +234,7 @@
         }
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json",
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json",
         "https://stac-extensions.github.io/datacube/v2.0.0/schema.json"
     ],
     "deltares:units": "m",

--- a/current/ssl/ssl-mapbox/ssl-mapbox-rp-10.0-scenarios-Historical.json
+++ b/current/ssl/ssl-mapbox/ssl-mapbox-rp-10.0-scenarios-Historical.json
@@ -109,7 +109,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "ssl"
 }

--- a/current/ssl/ssl-mapbox/ssl-mapbox-rp-10.0-scenarios-RCP45.json
+++ b/current/ssl/ssl-mapbox/ssl-mapbox-rp-10.0-scenarios-RCP45.json
@@ -109,7 +109,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "ssl"
 }

--- a/current/ssl/ssl-mapbox/ssl-mapbox-rp-10.0-scenarios-RCP85.json
+++ b/current/ssl/ssl-mapbox/ssl-mapbox-rp-10.0-scenarios-RCP85.json
@@ -109,7 +109,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "ssl"
 }

--- a/current/ssl/ssl-mapbox/ssl-mapbox-rp-100.0-scenarios-Historical.json
+++ b/current/ssl/ssl-mapbox/ssl-mapbox-rp-100.0-scenarios-Historical.json
@@ -109,7 +109,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "ssl"
 }

--- a/current/ssl/ssl-mapbox/ssl-mapbox-rp-100.0-scenarios-RCP45.json
+++ b/current/ssl/ssl-mapbox/ssl-mapbox-rp-100.0-scenarios-RCP45.json
@@ -109,7 +109,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "ssl"
 }

--- a/current/ssl/ssl-mapbox/ssl-mapbox-rp-100.0-scenarios-RCP85.json
+++ b/current/ssl/ssl-mapbox/ssl-mapbox-rp-100.0-scenarios-RCP85.json
@@ -109,7 +109,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "ssl"
 }

--- a/current/ssl/ssl-mapbox/ssl-mapbox-rp-1000.0-scenarios-Historical.json
+++ b/current/ssl/ssl-mapbox/ssl-mapbox-rp-1000.0-scenarios-Historical.json
@@ -109,7 +109,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "ssl"
 }

--- a/current/ssl/ssl-mapbox/ssl-mapbox-rp-1000.0-scenarios-RCP45.json
+++ b/current/ssl/ssl-mapbox/ssl-mapbox-rp-1000.0-scenarios-RCP45.json
@@ -109,7 +109,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "ssl"
 }

--- a/current/ssl/ssl-mapbox/ssl-mapbox-rp-1000.0-scenarios-RCP85.json
+++ b/current/ssl/ssl-mapbox/ssl-mapbox-rp-1000.0-scenarios-RCP85.json
@@ -109,7 +109,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "ssl"
 }

--- a/current/ssl/ssl-mapbox/ssl-mapbox-rp-20.0-scenarios-Historical.json
+++ b/current/ssl/ssl-mapbox/ssl-mapbox-rp-20.0-scenarios-Historical.json
@@ -109,7 +109,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "ssl"
 }

--- a/current/ssl/ssl-mapbox/ssl-mapbox-rp-20.0-scenarios-RCP45.json
+++ b/current/ssl/ssl-mapbox/ssl-mapbox-rp-20.0-scenarios-RCP45.json
@@ -109,7 +109,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "ssl"
 }

--- a/current/ssl/ssl-mapbox/ssl-mapbox-rp-20.0-scenarios-RCP85.json
+++ b/current/ssl/ssl-mapbox/ssl-mapbox-rp-20.0-scenarios-RCP85.json
@@ -109,7 +109,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "ssl"
 }

--- a/current/ssl/ssl-mapbox/ssl-mapbox-rp-200.0-scenarios-Historical.json
+++ b/current/ssl/ssl-mapbox/ssl-mapbox-rp-200.0-scenarios-Historical.json
@@ -109,7 +109,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "ssl"
 }

--- a/current/ssl/ssl-mapbox/ssl-mapbox-rp-200.0-scenarios-RCP45.json
+++ b/current/ssl/ssl-mapbox/ssl-mapbox-rp-200.0-scenarios-RCP45.json
@@ -109,7 +109,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "ssl"
 }

--- a/current/ssl/ssl-mapbox/ssl-mapbox-rp-200.0-scenarios-RCP85.json
+++ b/current/ssl/ssl-mapbox/ssl-mapbox-rp-200.0-scenarios-RCP85.json
@@ -109,7 +109,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "ssl"
 }

--- a/current/ssl/ssl-mapbox/ssl-mapbox-rp-5.0-scenarios-Historical.json
+++ b/current/ssl/ssl-mapbox/ssl-mapbox-rp-5.0-scenarios-Historical.json
@@ -109,7 +109,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "ssl"
 }

--- a/current/ssl/ssl-mapbox/ssl-mapbox-rp-5.0-scenarios-RCP45.json
+++ b/current/ssl/ssl-mapbox/ssl-mapbox-rp-5.0-scenarios-RCP45.json
@@ -109,7 +109,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "ssl"
 }

--- a/current/ssl/ssl-mapbox/ssl-mapbox-rp-5.0-scenarios-RCP85.json
+++ b/current/ssl/ssl-mapbox/ssl-mapbox-rp-5.0-scenarios-RCP85.json
@@ -109,7 +109,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "ssl"
 }

--- a/current/ssl/ssl-mapbox/ssl-mapbox-rp-50.0-scenarios-Historical.json
+++ b/current/ssl/ssl-mapbox/ssl-mapbox-rp-50.0-scenarios-Historical.json
@@ -109,7 +109,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "ssl"
 }

--- a/current/ssl/ssl-mapbox/ssl-mapbox-rp-50.0-scenarios-RCP45.json
+++ b/current/ssl/ssl-mapbox/ssl-mapbox-rp-50.0-scenarios-RCP45.json
@@ -109,7 +109,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "ssl"
 }

--- a/current/ssl/ssl-mapbox/ssl-mapbox-rp-50.0-scenarios-RCP85.json
+++ b/current/ssl/ssl-mapbox/ssl-mapbox-rp-50.0-scenarios-RCP85.json
@@ -109,7 +109,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "ssl"
 }

--- a/current/ssl/ssl-mapbox/ssl-mapbox-rp-500.0-scenarios-Historical.json
+++ b/current/ssl/ssl-mapbox/ssl-mapbox-rp-500.0-scenarios-Historical.json
@@ -109,7 +109,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "ssl"
 }

--- a/current/ssl/ssl-mapbox/ssl-mapbox-rp-500.0-scenarios-RCP45.json
+++ b/current/ssl/ssl-mapbox/ssl-mapbox-rp-500.0-scenarios-RCP45.json
@@ -109,7 +109,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "ssl"
 }

--- a/current/ssl/ssl-mapbox/ssl-mapbox-rp-500.0-scenarios-RCP85.json
+++ b/current/ssl/ssl-mapbox/ssl-mapbox-rp-500.0-scenarios-RCP85.json
@@ -109,7 +109,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "ssl"
 }

--- a/current/wef/collection.json
+++ b/current/wef/collection.json
@@ -810,7 +810,7 @@
         }
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json",
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json",
         "https://stac-extensions.github.io/datacube/v2.0.0/schema.json"
     ],
     "deltares:units": "m",

--- a/current/wef/wef-mapbox/wef-mapbox-rp-10.0-time-1995.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-10.0-time-1995.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-10.0-time-2010.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-10.0-time-2010.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-10.0-time-2020.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-10.0-time-2020.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-10.0-time-2030.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-10.0-time-2030.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-10.0-time-2040.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-10.0-time-2040.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-10.0-time-2050.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-10.0-time-2050.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-10.0-time-2060.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-10.0-time-2060.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-10.0-time-2070.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-10.0-time-2070.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-10.0-time-2080.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-10.0-time-2080.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-10.0-time-2090.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-10.0-time-2090.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-10.0-time-2100.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-10.0-time-2100.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-100.0-time-1995.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-100.0-time-1995.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-100.0-time-2010.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-100.0-time-2010.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-100.0-time-2020.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-100.0-time-2020.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-100.0-time-2030.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-100.0-time-2030.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-100.0-time-2040.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-100.0-time-2040.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-100.0-time-2050.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-100.0-time-2050.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-100.0-time-2060.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-100.0-time-2060.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-100.0-time-2070.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-100.0-time-2070.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-100.0-time-2080.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-100.0-time-2080.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-100.0-time-2090.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-100.0-time-2090.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-100.0-time-2100.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-100.0-time-2100.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-1000.0-time-1995.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-1000.0-time-1995.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-1000.0-time-2010.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-1000.0-time-2010.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-1000.0-time-2020.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-1000.0-time-2020.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-1000.0-time-2030.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-1000.0-time-2030.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-1000.0-time-2040.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-1000.0-time-2040.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-1000.0-time-2050.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-1000.0-time-2050.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-1000.0-time-2060.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-1000.0-time-2060.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-1000.0-time-2070.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-1000.0-time-2070.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-1000.0-time-2080.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-1000.0-time-2080.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-1000.0-time-2090.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-1000.0-time-2090.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-1000.0-time-2100.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-1000.0-time-2100.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-20.0-time-1995.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-20.0-time-1995.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-20.0-time-2010.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-20.0-time-2010.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-20.0-time-2020.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-20.0-time-2020.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-20.0-time-2030.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-20.0-time-2030.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-20.0-time-2040.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-20.0-time-2040.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-20.0-time-2050.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-20.0-time-2050.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-20.0-time-2060.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-20.0-time-2060.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-20.0-time-2070.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-20.0-time-2070.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-20.0-time-2080.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-20.0-time-2080.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-20.0-time-2090.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-20.0-time-2090.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-20.0-time-2100.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-20.0-time-2100.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-200.0-time-1995.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-200.0-time-1995.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-200.0-time-2010.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-200.0-time-2010.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-200.0-time-2020.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-200.0-time-2020.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-200.0-time-2030.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-200.0-time-2030.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-200.0-time-2040.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-200.0-time-2040.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-200.0-time-2050.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-200.0-time-2050.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-200.0-time-2060.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-200.0-time-2060.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-200.0-time-2070.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-200.0-time-2070.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-200.0-time-2080.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-200.0-time-2080.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-200.0-time-2090.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-200.0-time-2090.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-200.0-time-2100.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-200.0-time-2100.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-5.0-time-1995.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-5.0-time-1995.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-5.0-time-2010.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-5.0-time-2010.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-5.0-time-2020.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-5.0-time-2020.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-5.0-time-2030.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-5.0-time-2030.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-5.0-time-2040.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-5.0-time-2040.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-5.0-time-2050.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-5.0-time-2050.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-5.0-time-2060.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-5.0-time-2060.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-5.0-time-2070.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-5.0-time-2070.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-5.0-time-2080.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-5.0-time-2080.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-5.0-time-2090.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-5.0-time-2090.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-5.0-time-2100.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-5.0-time-2100.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-50.0-time-1995.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-50.0-time-1995.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-50.0-time-2010.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-50.0-time-2010.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-50.0-time-2020.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-50.0-time-2020.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-50.0-time-2030.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-50.0-time-2030.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-50.0-time-2040.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-50.0-time-2040.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-50.0-time-2050.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-50.0-time-2050.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-50.0-time-2060.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-50.0-time-2060.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-50.0-time-2070.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-50.0-time-2070.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-50.0-time-2080.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-50.0-time-2080.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-50.0-time-2090.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-50.0-time-2090.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-50.0-time-2100.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-50.0-time-2100.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-500.0-time-1995.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-500.0-time-1995.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-500.0-time-2010.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-500.0-time-2010.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-500.0-time-2020.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-500.0-time-2020.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-500.0-time-2030.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-500.0-time-2030.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-500.0-time-2040.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-500.0-time-2040.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-500.0-time-2050.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-500.0-time-2050.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-500.0-time-2060.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-500.0-time-2060.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-500.0-time-2070.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-500.0-time-2070.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-500.0-time-2080.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-500.0-time-2080.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-500.0-time-2090.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-500.0-time-2090.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }

--- a/current/wef/wef-mapbox/wef-mapbox-rp-500.0-time-2100.0.json
+++ b/current/wef/wef-mapbox/wef-mapbox-rp-500.0-time-2100.0.json
@@ -110,7 +110,7 @@
         90
     ],
     "stac_extensions": [
-        "https://raw.githubusercontent.com/openearth/coclicodata/feat/update-deltares-stac-properties/json-schema/schema.json"
+        "https://raw.githubusercontent.com/openearth/coclicodata/main/json-schema/schema.json"
     ],
     "collection": "wef"
 }


### PR DESCRIPTION
- set Deltares stac extension hrefs in to the schema in the main branch. It was something like https://github.com/openearth/coclicodata/blob/feat/update-deltares-stac-properties/json-schema/schema.json; now its https://github.com/openearth/coclicodata/blob/main/json-schema/schema.json