### PR TITLE
add transects dataset to coclico stac

### DIFF
--- a/current/catalog.json
+++ b/current/catalog.json
@@ -57,6 +57,12 @@
             "href": "./slp6_pilot/collection.json",
             "type": "application/json",
             "title": "Sea level projections"
+        },
+        {
+            "rel": "child",
+            "href": "./gcts-2000-z9/collection.json",
+            "type": "application/json",
+            "title": "Global Coastal Transect System Zoom 9"
         }
     ],
     "assets": {

--- a/current/gcts-2000-z9/collection.json
+++ b/current/gcts-2000-z9/collection.json
@@ -1,0 +1,202 @@
+{
+    "type": "Collection",
+    "id": "gcts-2000-z9",
+    "stac_version": "1.0.0",
+    "description": "The Global Coastal Transect System Zoom 9 consists 2000 m long cross-shore transects that are placed at equally-spaced 100 m alongshore resolution. The transects are derived from a generalized open street map coastline (2023-02-22) at zoom level 9. ",
+    "links": [
+        {
+            "rel": "license",
+            "href": "https://creativecommons.org/publicdomain/zero/1.0/",
+            "type": "text/html",
+            "title": "CC License"
+        },
+        {
+            "rel": "item",
+            "href": "./quadkey=qk00_part.0.parquet/quadkey=qk00_part.0.parquet.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "item",
+            "href": "./quadkey=qk01_part.1.parquet/quadkey=qk01_part.1.parquet.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "item",
+            "href": "./quadkey=qk02_part.2.parquet/quadkey=qk02_part.2.parquet.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "item",
+            "href": "./quadkey=qk030_part.3.parquet/quadkey=qk030_part.3.parquet.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "item",
+            "href": "./quadkey=qk031_part.4.parquet/quadkey=qk031_part.4.parquet.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "item",
+            "href": "./quadkey=qk032_part.5.parquet/quadkey=qk032_part.5.parquet.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "item",
+            "href": "./quadkey=qk033_part.6.parquet/quadkey=qk033_part.6.parquet.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "item",
+            "href": "./quadkey=qk10_part.7.parquet/quadkey=qk10_part.7.parquet.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "item",
+            "href": "./quadkey=qk11_part.8.parquet/quadkey=qk11_part.8.parquet.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "item",
+            "href": "./quadkey=qk12_part.9.parquet/quadkey=qk12_part.9.parquet.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "item",
+            "href": "./quadkey=qk13_part.10.parquet/quadkey=qk13_part.10.parquet.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "item",
+            "href": "./quadkey=qk20_part.11.parquet/quadkey=qk20_part.11.parquet.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "item",
+            "href": "./quadkey=qk21_part.12.parquet/quadkey=qk21_part.12.parquet.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "item",
+            "href": "./quadkey=qk22_part.13.parquet/quadkey=qk22_part.13.parquet.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "item",
+            "href": "./quadkey=qk23_part.14.parquet/quadkey=qk23_part.14.parquet.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "item",
+            "href": "./quadkey=qk30_part.15.parquet/quadkey=qk30_part.15.parquet.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "item",
+            "href": "./quadkey=qk31_part.16.parquet/quadkey=qk31_part.16.parquet.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "item",
+            "href": "./quadkey=qk32_part.17.parquet/quadkey=qk32_part.17.parquet.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "item",
+            "href": "./quadkey=qk33_part.18.parquet/quadkey=qk33_part.18.parquet.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "root",
+            "href": "../catalog.json",
+            "type": "application/json",
+            "title": "CoCliCo STAC Catalog"
+        },
+        {
+            "rel": "parent",
+            "href": "../catalog.json",
+            "type": "application/json",
+            "title": "CoCliCo STAC Catalog"
+        }
+    ],
+    "stac_extensions": [
+        "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/scientific/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/table/v1.2.0/schema.json",
+        "https://stac-extensions.github.io/version/v1.0.0/schema.json"
+    ],
+    "item_assets": {
+        "data": {
+            "title": "Coastal Transects",
+            "description": "Coastal transects of 2000 m derived at OSM zoom level 9 for this region. ",
+            "roles": [
+                "data"
+            ],
+            "type": "application/x-parquet",
+            "table:storage_options": {
+                "account_name": "coclico"
+            },
+            "table:columns": [
+                {
+                    "name": "geometry",
+                    "type": "byte_array",
+                    "description": "Building footprint linestrings"
+                }
+            ]
+        }
+    },
+    "sci:citation": "Calkoen et al., 2023, in progress. ",
+    "version": 1,
+    "title": "Global Coastal Transect System Zoom 9",
+    "extent": {
+        "spatial": {
+            "bbox": [
+                [
+                    -179.99979946036342,
+                    -78.74747176732404,
+                    179.99987183421385,
+                    83.66967471602302
+                ]
+            ]
+        },
+        "temporal": {
+            "interval": [
+                [
+                    "2023-10-27T00:00:00Z",
+                    "2023-10-27T00:00:00Z"
+                ]
+            ]
+        }
+    },
+    "license": "ODbL-1.0",
+    "keywords": [
+        "Coast",
+        "Coastal",
+        "Transects",
+        "Coastal transects",
+        "Coastal Change",
+        "Satellite-derived shorelines",
+        "SDS",
+        "CoCliCo",
+        "Deltares",
+        "GeoParquet"
+    ],
+    "providers": [
+        {
+            "name": "Deltares",
+            "roles": [
+                "producer",
+                "processor",
+                "host",
+                "licensor"
+            ],
+            "url": "https://deltares.nl"
+        }
+    ],
+    "assets": {
+        "thumbnail": {
+            "href": "https://coclico.blob.core.windows.net/assets/thumbnails/gcts-thumbnail.jpeg",
+            "type": "image/jpeg",
+            "title": "Thumbnail"
+        }
+    }
+}

--- a/current/gcts-2000-z9/collection.json
+++ b/current/gcts-2000-z9/collection.json
@@ -145,7 +145,7 @@
         }
     },
     "sci:citation": "Calkoen et al., 2023, in progress. ",
-    "version": 1,
+    "version": "1",
     "title": "Global Coastal Transect System Zoom 9",
     "extent": {
         "spatial": {

--- a/current/gcts-2000-z9/quadkey=qk00_part.0.parquet/quadkey=qk00_part.0.parquet.json
+++ b/current/gcts-2000-z9/quadkey=qk00_part.0.parquet/quadkey=qk00_part.0.parquet.json
@@ -1,0 +1,119 @@
+{
+    "type": "Feature",
+    "stac_version": "1.0.0",
+    "id": "quadkey=qk00_part.0.parquet",
+    "properties": {
+        "title": "Coastal Transects",
+        "description": "Parquet dataset with the coastal transects",
+        "coclico:quadkey": "00",
+        "table:columns": [
+            {
+                "name": "tr_name",
+                "type": "byte_array",
+                "description": "Building footprint linestrings"
+            },
+            {
+                "name": "lon",
+                "type": "float"
+            },
+            {
+                "name": "lat",
+                "type": "float"
+            },
+            {
+                "name": "bearing",
+                "type": "float"
+            },
+            {
+                "name": "utm_crs",
+                "type": "int32"
+            },
+            {
+                "name": "coastline_name",
+                "type": "int32"
+            },
+            {
+                "name": "geometry",
+                "type": "byte_array"
+            }
+        ],
+        "proj:bbox": [
+            -20037480.72065479,
+            10016609.159998018,
+            -10013988.128357515,
+            16919478.696529582
+        ],
+        "proj:epsg": 3857,
+        "table:row_count": 650160,
+        "datetime": "2023-10-27T00:00:00Z"
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    -90.0,
+                    66.51326044311186
+                ],
+                [
+                    -90.0,
+                    85.0511287798066
+                ],
+                [
+                    -180.0,
+                    85.0511287798066
+                ],
+                [
+                    -180.0,
+                    66.51326044311186
+                ],
+                [
+                    -90.0,
+                    66.51326044311186
+                ]
+            ]
+        ]
+    },
+    "links": [
+        {
+            "rel": "collection",
+            "href": "../collection.json",
+            "type": "application/json",
+            "title": "Global Coastal Transect System Zoom 9"
+        },
+        {
+            "rel": "root",
+            "href": "../../catalog.json",
+            "type": "application/json",
+            "title": "CoCliCo STAC Catalog"
+        },
+        {
+            "rel": "parent",
+            "href": "../collection.json",
+            "type": "application/json",
+            "title": "Global Coastal Transect System Zoom 9"
+        }
+    ],
+    "assets": {
+        "data": {
+            "href": "az://transects/length-2000.parquet/quadkey=qk00/part.0.parquet",
+            "type": "application/x-parquet",
+            "title": "Coastal Transects",
+            "description": "Parquet dataset with the coastal transects for this region.",
+            "roles": [
+                "data"
+            ]
+        }
+    },
+    "bbox": [
+        -179.9997518661444,
+        66.50557986664505,
+        -89.95718590694996,
+        81.93936474444614
+    ],
+    "stac_extensions": [
+        "https://stac-extensions.github.io/table/v1.2.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
+    ],
+    "collection": "gcts-2000-z9"
+}

--- a/current/gcts-2000-z9/quadkey=qk01_part.1.parquet/quadkey=qk01_part.1.parquet.json
+++ b/current/gcts-2000-z9/quadkey=qk01_part.1.parquet/quadkey=qk01_part.1.parquet.json
@@ -1,0 +1,119 @@
+{
+    "type": "Feature",
+    "stac_version": "1.0.0",
+    "id": "quadkey=qk01_part.1.parquet",
+    "properties": {
+        "title": "Coastal Transects",
+        "description": "Parquet dataset with the coastal transects",
+        "coclico:quadkey": "01",
+        "table:columns": [
+            {
+                "name": "tr_name",
+                "type": "byte_array",
+                "description": "Building footprint linestrings"
+            },
+            {
+                "name": "lon",
+                "type": "float"
+            },
+            {
+                "name": "lat",
+                "type": "float"
+            },
+            {
+                "name": "bearing",
+                "type": "float"
+            },
+            {
+                "name": "utm_crs",
+                "type": "int32"
+            },
+            {
+                "name": "coastline_name",
+                "type": "int32"
+            },
+            {
+                "name": "geometry",
+                "type": "byte_array"
+            }
+        ],
+        "proj:bbox": [
+            -10025355.070537282,
+            10016267.807902412,
+            -879827.3184337176,
+            18464735.65572306
+        ],
+        "proj:epsg": 3857,
+        "table:row_count": 803314,
+        "datetime": "2023-10-27T00:00:00Z"
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    0.0,
+                    66.51326044311186
+                ],
+                [
+                    0.0,
+                    85.0511287798066
+                ],
+                [
+                    -90.0,
+                    85.0511287798066
+                ],
+                [
+                    -90.0,
+                    66.51326044311186
+                ],
+                [
+                    0.0,
+                    66.51326044311186
+                ]
+            ]
+        ]
+    },
+    "links": [
+        {
+            "rel": "collection",
+            "href": "../collection.json",
+            "type": "application/json",
+            "title": "Global Coastal Transect System Zoom 9"
+        },
+        {
+            "rel": "root",
+            "href": "../../catalog.json",
+            "type": "application/json",
+            "title": "CoCliCo STAC Catalog"
+        },
+        {
+            "rel": "parent",
+            "href": "../collection.json",
+            "type": "application/json",
+            "title": "Global Coastal Transect System Zoom 9"
+        }
+    ],
+    "assets": {
+        "data": {
+            "href": "az://transects/length-2000.parquet/quadkey=qk01/part.1.parquet",
+            "type": "application/x-parquet",
+            "title": "Coastal Transects",
+            "description": "Parquet dataset with the coastal transects for this region.",
+            "roles": [
+                "data"
+            ]
+        }
+    },
+    "bbox": [
+        -90.05929688588783,
+        66.50435737916965,
+        -7.903623275349017,
+        83.66967471602302
+    ],
+    "stac_extensions": [
+        "https://stac-extensions.github.io/table/v1.2.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
+    ],
+    "collection": "gcts-2000-z9"
+}

--- a/current/gcts-2000-z9/quadkey=qk02_part.2.parquet/quadkey=qk02_part.2.parquet.json
+++ b/current/gcts-2000-z9/quadkey=qk02_part.2.parquet/quadkey=qk02_part.2.parquet.json
@@ -1,0 +1,119 @@
+{
+    "type": "Feature",
+    "stac_version": "1.0.0",
+    "id": "quadkey=qk02_part.2.parquet",
+    "properties": {
+        "title": "Coastal Transects",
+        "description": "Parquet dataset with the coastal transects",
+        "coclico:quadkey": "02",
+        "table:columns": [
+            {
+                "name": "tr_name",
+                "type": "byte_array",
+                "description": "Building footprint linestrings"
+            },
+            {
+                "name": "lon",
+                "type": "float"
+            },
+            {
+                "name": "lat",
+                "type": "float"
+            },
+            {
+                "name": "bearing",
+                "type": "float"
+            },
+            {
+                "name": "utm_crs",
+                "type": "int32"
+            },
+            {
+                "name": "coastline_name",
+                "type": "int32"
+            },
+            {
+                "name": "geometry",
+                "type": "byte_array"
+            }
+        ],
+        "proj:bbox": [
+            -20037422.07493277,
+            -840.0857350130634,
+            -10016625.147347517,
+            10020969.1588439
+        ],
+        "proj:epsg": 3857,
+        "table:row_count": 1000453,
+        "datetime": "2023-10-27T00:00:00Z"
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    -90.0,
+                    0.0
+                ],
+                [
+                    -90.0,
+                    66.51326044311186
+                ],
+                [
+                    -180.0,
+                    66.51326044311186
+                ],
+                [
+                    -180.0,
+                    0.0
+                ],
+                [
+                    -90.0,
+                    0.0
+                ]
+            ]
+        ]
+    },
+    "links": [
+        {
+            "rel": "collection",
+            "href": "../collection.json",
+            "type": "application/json",
+            "title": "Global Coastal Transect System Zoom 9"
+        },
+        {
+            "rel": "root",
+            "href": "../../catalog.json",
+            "type": "application/json",
+            "title": "CoCliCo STAC Catalog"
+        },
+        {
+            "rel": "parent",
+            "href": "../collection.json",
+            "type": "application/json",
+            "title": "Global Coastal Transect System Zoom 9"
+        }
+    ],
+    "assets": {
+        "data": {
+            "href": "az://transects/length-2000.parquet/quadkey=qk02/part.2.parquet",
+            "type": "application/x-parquet",
+            "title": "Coastal Transects",
+            "description": "Parquet dataset with the coastal transects for this region.",
+            "roles": [
+                "data"
+            ]
+        }
+    },
+    "bbox": [
+        -179.99922504266002,
+        -0.007546618535509873,
+        -89.98087465158228,
+        66.52118909485309
+    ],
+    "stac_extensions": [
+        "https://stac-extensions.github.io/table/v1.2.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
+    ],
+    "collection": "gcts-2000-z9"
+}

--- a/current/gcts-2000-z9/quadkey=qk030_part.3.parquet/quadkey=qk030_part.3.parquet.json
+++ b/current/gcts-2000-z9/quadkey=qk030_part.3.parquet/quadkey=qk030_part.3.parquet.json
@@ -1,0 +1,119 @@
+{
+    "type": "Feature",
+    "stac_version": "1.0.0",
+    "id": "quadkey=qk030_part.3.parquet",
+    "properties": {
+        "title": "Coastal Transects",
+        "description": "Parquet dataset with the coastal transects",
+        "coclico:quadkey": "030",
+        "table:columns": [
+            {
+                "name": "tr_name",
+                "type": "byte_array",
+                "description": "Building footprint linestrings"
+            },
+            {
+                "name": "lon",
+                "type": "float"
+            },
+            {
+                "name": "lat",
+                "type": "float"
+            },
+            {
+                "name": "bearing",
+                "type": "float"
+            },
+            {
+                "name": "utm_crs",
+                "type": "int32"
+            },
+            {
+                "name": "coastline_name",
+                "type": "int32"
+            },
+            {
+                "name": "geometry",
+                "type": "byte_array"
+            }
+        ],
+        "proj:bbox": [
+            -10020643.724056803,
+            5008054.504600144,
+            -5007675.034153109,
+            10020944.817342209
+        ],
+        "proj:epsg": 3857,
+        "table:row_count": 944338,
+        "datetime": "2023-10-27T00:00:00Z"
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    -45.0,
+                    40.97989806962013
+                ],
+                [
+                    -45.0,
+                    66.51326044311186
+                ],
+                [
+                    -90.0,
+                    66.51326044311186
+                ],
+                [
+                    -90.0,
+                    40.97989806962013
+                ],
+                [
+                    -45.0,
+                    40.97989806962013
+                ]
+            ]
+        ]
+    },
+    "links": [
+        {
+            "rel": "collection",
+            "href": "../collection.json",
+            "type": "application/json",
+            "title": "Global Coastal Transect System Zoom 9"
+        },
+        {
+            "rel": "root",
+            "href": "../../catalog.json",
+            "type": "application/json",
+            "title": "CoCliCo STAC Catalog"
+        },
+        {
+            "rel": "parent",
+            "href": "../collection.json",
+            "type": "application/json",
+            "title": "Global Coastal Transect System Zoom 9"
+        }
+    ],
+    "assets": {
+        "data": {
+            "href": "az://transects/length-2000.parquet/quadkey=qk030/part.3.parquet",
+            "type": "application/x-parquet",
+            "title": "Coastal Transects",
+            "description": "Parquet dataset with the coastal transects for this region.",
+            "roles": [
+                "data"
+            ]
+        }
+    },
+    "bbox": [
+        -90.01697414036586,
+        40.970928060241555,
+        -44.98471021083485,
+        66.5211019770264
+    ],
+    "stac_extensions": [
+        "https://stac-extensions.github.io/table/v1.2.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
+    ],
+    "collection": "gcts-2000-z9"
+}

--- a/current/gcts-2000-z9/quadkey=qk031_part.4.parquet/quadkey=qk031_part.4.parquet.json
+++ b/current/gcts-2000-z9/quadkey=qk031_part.4.parquet/quadkey=qk031_part.4.parquet.json
@@ -1,0 +1,119 @@
+{
+    "type": "Feature",
+    "stac_version": "1.0.0",
+    "id": "quadkey=qk031_part.4.parquet",
+    "properties": {
+        "title": "Coastal Transects",
+        "description": "Parquet dataset with the coastal transects",
+        "coclico:quadkey": "031",
+        "table:columns": [
+            {
+                "name": "tr_name",
+                "type": "byte_array",
+                "description": "Building footprint linestrings"
+            },
+            {
+                "name": "lon",
+                "type": "float"
+            },
+            {
+                "name": "lat",
+                "type": "float"
+            },
+            {
+                "name": "bearing",
+                "type": "float"
+            },
+            {
+                "name": "utm_crs",
+                "type": "int32"
+            },
+            {
+                "name": "coastline_name",
+                "type": "int32"
+            },
+            {
+                "name": "geometry",
+                "type": "byte_array"
+            }
+        ],
+        "proj:bbox": [
+            -5011072.354854029,
+            5009418.228879124,
+            -13.760160608726327,
+            10021212.044580124
+        ],
+        "proj:epsg": 3857,
+        "table:row_count": 405505,
+        "datetime": "2023-10-27T00:00:00Z"
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    0.0,
+                    40.97989806962013
+                ],
+                [
+                    0.0,
+                    66.51326044311186
+                ],
+                [
+                    -45.0,
+                    66.51326044311186
+                ],
+                [
+                    -45.0,
+                    40.97989806962013
+                ],
+                [
+                    0.0,
+                    40.97989806962013
+                ]
+            ]
+        ]
+    },
+    "links": [
+        {
+            "rel": "collection",
+            "href": "../collection.json",
+            "type": "application/json",
+            "title": "Global Coastal Transect System Zoom 9"
+        },
+        {
+            "rel": "root",
+            "href": "../../catalog.json",
+            "type": "application/json",
+            "title": "CoCliCo STAC Catalog"
+        },
+        {
+            "rel": "parent",
+            "href": "../collection.json",
+            "type": "application/json",
+            "title": "Global Coastal Transect System Zoom 9"
+        }
+    ],
+    "assets": {
+        "data": {
+            "href": "az://transects/length-2000.parquet/quadkey=qk031/part.4.parquet",
+            "type": "application/x-parquet",
+            "title": "Coastal Transects",
+            "description": "Parquet dataset with the coastal transects for this region.",
+            "roles": [
+                "data"
+            ]
+        }
+    },
+    "bbox": [
+        -45.01522886194176,
+        40.98017709134197,
+        -0.00012360962586758237,
+        66.52205836213078
+    ],
+    "stac_extensions": [
+        "https://stac-extensions.github.io/table/v1.2.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
+    ],
+    "collection": "gcts-2000-z9"
+}

--- a/current/gcts-2000-z9/quadkey=qk032_part.5.parquet/quadkey=qk032_part.5.parquet.json
+++ b/current/gcts-2000-z9/quadkey=qk032_part.5.parquet/quadkey=qk032_part.5.parquet.json
@@ -1,0 +1,119 @@
+{
+    "type": "Feature",
+    "stac_version": "1.0.0",
+    "id": "quadkey=qk032_part.5.parquet",
+    "properties": {
+        "title": "Coastal Transects",
+        "description": "Parquet dataset with the coastal transects",
+        "coclico:quadkey": "032",
+        "table:columns": [
+            {
+                "name": "tr_name",
+                "type": "byte_array",
+                "description": "Building footprint linestrings"
+            },
+            {
+                "name": "lon",
+                "type": "float"
+            },
+            {
+                "name": "lat",
+                "type": "float"
+            },
+            {
+                "name": "bearing",
+                "type": "float"
+            },
+            {
+                "name": "utm_crs",
+                "type": "int32"
+            },
+            {
+                "name": "coastline_name",
+                "type": "int32"
+            },
+            {
+                "name": "geometry",
+                "type": "byte_array"
+            }
+        ],
+        "proj:bbox": [
+            -10019387.617756983,
+            -969.3398221100907,
+            -5493640.309457911,
+            5010702.070183
+        ],
+        "proj:epsg": 3857,
+        "table:row_count": 677694,
+        "datetime": "2023-10-27T00:00:00Z"
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    -45.0,
+                    0.0
+                ],
+                [
+                    -45.0,
+                    40.97989806962013
+                ],
+                [
+                    -90.0,
+                    40.97989806962013
+                ],
+                [
+                    -90.0,
+                    0.0
+                ],
+                [
+                    -45.0,
+                    0.0
+                ]
+            ]
+        ]
+    },
+    "links": [
+        {
+            "rel": "collection",
+            "href": "../collection.json",
+            "type": "application/json",
+            "title": "Global Coastal Transect System Zoom 9"
+        },
+        {
+            "rel": "root",
+            "href": "../../catalog.json",
+            "type": "application/json",
+            "title": "CoCliCo STAC Catalog"
+        },
+        {
+            "rel": "parent",
+            "href": "../collection.json",
+            "type": "application/json",
+            "title": "Global Coastal Transect System Zoom 9"
+        }
+    ],
+    "assets": {
+        "data": {
+            "href": "az://transects/length-2000.parquet/quadkey=qk032/part.5.parquet",
+            "type": "application/x-parquet",
+            "title": "Coastal Transects",
+            "description": "Parquet dataset with the coastal transects for this region.",
+            "roles": [
+                "data"
+            ]
+        }
+    },
+    "bbox": [
+        -90.0056903454898,
+        -0.008707727743550844,
+        -49.35021055441139,
+        40.98888315621542
+    ],
+    "stac_extensions": [
+        "https://stac-extensions.github.io/table/v1.2.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
+    ],
+    "collection": "gcts-2000-z9"
+}

--- a/current/gcts-2000-z9/quadkey=qk033_part.6.parquet/quadkey=qk033_part.6.parquet.json
+++ b/current/gcts-2000-z9/quadkey=qk033_part.6.parquet/quadkey=qk033_part.6.parquet.json
@@ -1,0 +1,119 @@
+{
+    "type": "Feature",
+    "stac_version": "1.0.0",
+    "id": "quadkey=qk033_part.6.parquet",
+    "properties": {
+        "title": "Coastal Transects",
+        "description": "Parquet dataset with the coastal transects",
+        "coclico:quadkey": "033",
+        "table:columns": [
+            {
+                "name": "tr_name",
+                "type": "byte_array",
+                "description": "Building footprint linestrings"
+            },
+            {
+                "name": "lon",
+                "type": "float"
+            },
+            {
+                "name": "lat",
+                "type": "float"
+            },
+            {
+                "name": "bearing",
+                "type": "float"
+            },
+            {
+                "name": "utm_crs",
+                "type": "int32"
+            },
+            {
+                "name": "coastline_name",
+                "type": "int32"
+            },
+            {
+                "name": "geometry",
+                "type": "byte_array"
+            }
+        ],
+        "proj:bbox": [
+            -3481827.312527521,
+            484252.1278211982,
+            -1.30833536935132,
+            5009483.830226776
+        ],
+        "proj:epsg": 3857,
+        "table:row_count": 195581,
+        "datetime": "2023-10-27T00:00:00Z"
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    0.0,
+                    0.0
+                ],
+                [
+                    0.0,
+                    40.97989806962013
+                ],
+                [
+                    -45.0,
+                    40.97989806962013
+                ],
+                [
+                    -45.0,
+                    0.0
+                ],
+                [
+                    0.0,
+                    0.0
+                ]
+            ]
+        ]
+    },
+    "links": [
+        {
+            "rel": "collection",
+            "href": "../collection.json",
+            "type": "application/json",
+            "title": "Global Coastal Transect System Zoom 9"
+        },
+        {
+            "rel": "root",
+            "href": "../../catalog.json",
+            "type": "application/json",
+            "title": "CoCliCo STAC Catalog"
+        },
+        {
+            "rel": "parent",
+            "href": "../collection.json",
+            "type": "application/json",
+            "title": "Global Coastal Transect System Zoom 9"
+        }
+    ],
+    "assets": {
+        "data": {
+            "href": "az://transects/length-2000.parquet/quadkey=qk033/part.6.parquet",
+            "type": "application/x-parquet",
+            "title": "Coastal Transects",
+            "description": "Parquet dataset with the coastal transects for this region.",
+            "roles": [
+                "data"
+            ]
+        }
+    },
+    "bbox": [
+        -31.2777869150827,
+        4.345937581813707,
+        -1.1752976590424499e-05,
+        40.98062197916353
+    ],
+    "stac_extensions": [
+        "https://stac-extensions.github.io/table/v1.2.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
+    ],
+    "collection": "gcts-2000-z9"
+}

--- a/current/gcts-2000-z9/quadkey=qk10_part.7.parquet/quadkey=qk10_part.7.parquet.json
+++ b/current/gcts-2000-z9/quadkey=qk10_part.7.parquet/quadkey=qk10_part.7.parquet.json
@@ -1,0 +1,119 @@
+{
+    "type": "Feature",
+    "stac_version": "1.0.0",
+    "id": "quadkey=qk10_part.7.parquet",
+    "properties": {
+        "title": "Coastal Transects",
+        "description": "Parquet dataset with the coastal transects",
+        "coclico:quadkey": "10",
+        "table:columns": [
+            {
+                "name": "tr_name",
+                "type": "byte_array",
+                "description": "Building footprint linestrings"
+            },
+            {
+                "name": "lon",
+                "type": "float"
+            },
+            {
+                "name": "lat",
+                "type": "float"
+            },
+            {
+                "name": "bearing",
+                "type": "float"
+            },
+            {
+                "name": "utm_crs",
+                "type": "int32"
+            },
+            {
+                "name": "coastline_name",
+                "type": "int32"
+            },
+            {
+                "name": "geometry",
+                "type": "byte_array"
+            }
+        ],
+        "proj:bbox": [
+            1159437.9571888114,
+            10016331.491067257,
+            10021866.50355429,
+            16862731.099513564
+        ],
+        "proj:epsg": 3857,
+        "table:row_count": 523907,
+        "datetime": "2023-10-27T00:00:00Z"
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    90.0,
+                    66.51326044311186
+                ],
+                [
+                    90.0,
+                    85.0511287798066
+                ],
+                [
+                    0.0,
+                    85.0511287798066
+                ],
+                [
+                    0.0,
+                    66.51326044311186
+                ],
+                [
+                    90.0,
+                    66.51326044311186
+                ]
+            ]
+        ]
+    },
+    "links": [
+        {
+            "rel": "collection",
+            "href": "../collection.json",
+            "type": "application/json",
+            "title": "Global Coastal Transect System Zoom 9"
+        },
+        {
+            "rel": "root",
+            "href": "../../catalog.json",
+            "type": "application/json",
+            "title": "CoCliCo STAC Catalog"
+        },
+        {
+            "rel": "parent",
+            "href": "../collection.json",
+            "type": "application/json",
+            "title": "Global Coastal Transect System Zoom 9"
+        }
+    ],
+    "assets": {
+        "data": {
+            "href": "az://transects/length-2000.parquet/quadkey=qk10/part.7.parquet",
+            "type": "application/x-parquet",
+            "title": "Coastal Transects",
+            "description": "Parquet dataset with the coastal transects for this region.",
+            "roles": [
+                "data"
+            ]
+        }
+    },
+    "bbox": [
+        10.415408379310247,
+        66.50458545284066,
+        90.02795855548287,
+        81.86756819737198
+    ],
+    "stac_extensions": [
+        "https://stac-extensions.github.io/table/v1.2.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
+    ],
+    "collection": "gcts-2000-z9"
+}

--- a/current/gcts-2000-z9/quadkey=qk11_part.8.parquet/quadkey=qk11_part.8.parquet.json
+++ b/current/gcts-2000-z9/quadkey=qk11_part.8.parquet/quadkey=qk11_part.8.parquet.json
@@ -1,0 +1,119 @@
+{
+    "type": "Feature",
+    "stac_version": "1.0.0",
+    "id": "quadkey=qk11_part.8.parquet",
+    "properties": {
+        "title": "Coastal Transects",
+        "description": "Parquet dataset with the coastal transects",
+        "coclico:quadkey": "11",
+        "table:columns": [
+            {
+                "name": "tr_name",
+                "type": "byte_array",
+                "description": "Building footprint linestrings"
+            },
+            {
+                "name": "lon",
+                "type": "float"
+            },
+            {
+                "name": "lat",
+                "type": "float"
+            },
+            {
+                "name": "bearing",
+                "type": "float"
+            },
+            {
+                "name": "utm_crs",
+                "type": "int32"
+            },
+            {
+                "name": "coastline_name",
+                "type": "int32"
+            },
+            {
+                "name": "geometry",
+                "type": "byte_array"
+            }
+        ],
+        "proj:bbox": [
+            10015556.388984285,
+            10675322.357900562,
+            20037492.697249807,
+            16418812.476192378
+        ],
+        "proj:epsg": 3857,
+        "table:row_count": 262135,
+        "datetime": "2023-10-27T00:00:00Z"
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    180.0,
+                    66.51326044311186
+                ],
+                [
+                    180.0,
+                    85.0511287798066
+                ],
+                [
+                    90.0,
+                    85.0511287798066
+                ],
+                [
+                    90.0,
+                    66.51326044311186
+                ],
+                [
+                    180.0,
+                    66.51326044311186
+                ]
+            ]
+        ]
+    },
+    "links": [
+        {
+            "rel": "collection",
+            "href": "../collection.json",
+            "type": "application/json",
+            "title": "Global Coastal Transect System Zoom 9"
+        },
+        {
+            "rel": "root",
+            "href": "../../catalog.json",
+            "type": "application/json",
+            "title": "CoCliCo STAC Catalog"
+        },
+        {
+            "rel": "parent",
+            "href": "../collection.json",
+            "type": "application/json",
+            "title": "Global Coastal Transect System Zoom 9"
+        }
+    ],
+    "assets": {
+        "data": {
+            "href": "az://transects/length-2000.parquet/quadkey=qk11/part.8.parquet",
+            "type": "application/x-parquet",
+            "title": "Coastal Transects",
+            "description": "Parquet dataset with the coastal transects for this region.",
+            "roles": [
+                "data"
+            ]
+        }
+    },
+    "bbox": [
+        89.97127383185507,
+        68.75571417997578,
+        179.99985945372796,
+        81.28357106532803
+    ],
+    "stac_extensions": [
+        "https://stac-extensions.github.io/table/v1.2.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
+    ],
+    "collection": "gcts-2000-z9"
+}

--- a/current/gcts-2000-z9/quadkey=qk12_part.9.parquet/quadkey=qk12_part.9.parquet.json
+++ b/current/gcts-2000-z9/quadkey=qk12_part.9.parquet/quadkey=qk12_part.9.parquet.json
@@ -1,0 +1,119 @@
+{
+    "type": "Feature",
+    "stac_version": "1.0.0",
+    "id": "quadkey=qk12_part.9.parquet",
+    "properties": {
+        "title": "Coastal Transects",
+        "description": "Parquet dataset with the coastal transects",
+        "coclico:quadkey": "12",
+        "table:columns": [
+            {
+                "name": "tr_name",
+                "type": "byte_array",
+                "description": "Building footprint linestrings"
+            },
+            {
+                "name": "lon",
+                "type": "float"
+            },
+            {
+                "name": "lat",
+                "type": "float"
+            },
+            {
+                "name": "bearing",
+                "type": "float"
+            },
+            {
+                "name": "utm_crs",
+                "type": "int32"
+            },
+            {
+                "name": "coastline_name",
+                "type": "int32"
+            },
+            {
+                "name": "geometry",
+                "type": "byte_array"
+            }
+        ],
+        "proj:bbox": [
+            1.4176786933087266,
+            -665.7876775912424,
+            10018971.729121653,
+            10021244.283395119
+        ],
+        "proj:epsg": 3857,
+        "table:row_count": 1564508,
+        "datetime": "2023-10-27T00:00:00Z"
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    90.0,
+                    0.0
+                ],
+                [
+                    90.0,
+                    66.51326044311186
+                ],
+                [
+                    0.0,
+                    66.51326044311186
+                ],
+                [
+                    0.0,
+                    0.0
+                ],
+                [
+                    90.0,
+                    0.0
+                ]
+            ]
+        ]
+    },
+    "links": [
+        {
+            "rel": "collection",
+            "href": "../collection.json",
+            "type": "application/json",
+            "title": "Global Coastal Transect System Zoom 9"
+        },
+        {
+            "rel": "root",
+            "href": "../../catalog.json",
+            "type": "application/json",
+            "title": "CoCliCo STAC Catalog"
+        },
+        {
+            "rel": "parent",
+            "href": "../collection.json",
+            "type": "application/json",
+            "title": "Global Coastal Transect System Zoom 9"
+        }
+    ],
+    "assets": {
+        "data": {
+            "href": "az://transects/length-2000.parquet/quadkey=qk12/part.9.parquet",
+            "type": "application/x-parquet",
+            "title": "Coastal Transects",
+            "description": "Parquet dataset with the coastal transects for this region.",
+            "roles": [
+                "data"
+            ]
+        }
+    },
+    "bbox": [
+        1.2735224381698207e-05,
+        -0.00598087245672485,
+        90.00195435431371,
+        66.52217373981003
+    ],
+    "stac_extensions": [
+        "https://stac-extensions.github.io/table/v1.2.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
+    ],
+    "collection": "gcts-2000-z9"
+}

--- a/current/gcts-2000-z9/quadkey=qk13_part.10.parquet/quadkey=qk13_part.10.parquet.json
+++ b/current/gcts-2000-z9/quadkey=qk13_part.10.parquet/quadkey=qk13_part.10.parquet.json
@@ -1,0 +1,119 @@
+{
+    "type": "Feature",
+    "stac_version": "1.0.0",
+    "id": "quadkey=qk13_part.10.parquet",
+    "properties": {
+        "title": "Coastal Transects",
+        "description": "Parquet dataset with the coastal transects",
+        "coclico:quadkey": "13",
+        "table:columns": [
+            {
+                "name": "tr_name",
+                "type": "byte_array",
+                "description": "Building footprint linestrings"
+            },
+            {
+                "name": "lon",
+                "type": "float"
+            },
+            {
+                "name": "lat",
+                "type": "float"
+            },
+            {
+                "name": "bearing",
+                "type": "float"
+            },
+            {
+                "name": "utm_crs",
+                "type": "int32"
+            },
+            {
+                "name": "coastline_name",
+                "type": "int32"
+            },
+            {
+                "name": "geometry",
+                "type": "byte_array"
+            }
+        ],
+        "proj:bbox": [
+            10018462.337714667,
+            -984.4110952488214,
+            20037478.28041734,
+            9630509.280012991
+        ],
+        "proj:epsg": 3857,
+        "table:row_count": 1438133,
+        "datetime": "2023-10-27T00:00:00Z"
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    180.0,
+                    0.0
+                ],
+                [
+                    180.0,
+                    66.51326044311186
+                ],
+                [
+                    90.0,
+                    66.51326044311186
+                ],
+                [
+                    90.0,
+                    0.0
+                ],
+                [
+                    180.0,
+                    0.0
+                ]
+            ]
+        ]
+    },
+    "links": [
+        {
+            "rel": "collection",
+            "href": "../collection.json",
+            "type": "application/json",
+            "title": "Global Coastal Transect System Zoom 9"
+        },
+        {
+            "rel": "root",
+            "href": "../../catalog.json",
+            "type": "application/json",
+            "title": "CoCliCo STAC Catalog"
+        },
+        {
+            "rel": "parent",
+            "href": "../collection.json",
+            "type": "application/json",
+            "title": "Global Coastal Transect System Zoom 9"
+        }
+    ],
+    "assets": {
+        "data": {
+            "href": "az://transects/length-2000.parquet/quadkey=qk13/part.10.parquet",
+            "type": "application/x-parquet",
+            "title": "Coastal Transects",
+            "description": "Parquet dataset with the coastal transects for this region.",
+            "roles": [
+                "data"
+            ]
+        }
+    },
+    "bbox": [
+        89.99737841344876,
+        -0.00884311529207947,
+        179.99972994511845,
+        65.08391273317105
+    ],
+    "stac_extensions": [
+        "https://stac-extensions.github.io/table/v1.2.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
+    ],
+    "collection": "gcts-2000-z9"
+}

--- a/current/gcts-2000-z9/quadkey=qk20_part.11.parquet/quadkey=qk20_part.11.parquet.json
+++ b/current/gcts-2000-z9/quadkey=qk20_part.11.parquet/quadkey=qk20_part.11.parquet.json
@@ -1,0 +1,119 @@
+{
+    "type": "Feature",
+    "stac_version": "1.0.0",
+    "id": "quadkey=qk20_part.11.parquet",
+    "properties": {
+        "title": "Coastal Transects",
+        "description": "Parquet dataset with the coastal transects",
+        "coclico:quadkey": "20",
+        "table:columns": [
+            {
+                "name": "tr_name",
+                "type": "byte_array",
+                "description": "Building footprint linestrings"
+            },
+            {
+                "name": "lon",
+                "type": "float"
+            },
+            {
+                "name": "lat",
+                "type": "float"
+            },
+            {
+                "name": "bearing",
+                "type": "float"
+            },
+            {
+                "name": "utm_crs",
+                "type": "int32"
+            },
+            {
+                "name": "coastline_name",
+                "type": "int32"
+            },
+            {
+                "name": "geometry",
+                "type": "byte_array"
+            }
+        ],
+        "proj:bbox": [
+            -20037486.018819015,
+            -5522073.022931164,
+            -10021042.624299033,
+            785.4934064822164
+        ],
+        "proj:epsg": 3857,
+        "table:row_count": 85236,
+        "datetime": "2023-10-27T00:00:00Z"
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    -90.0,
+                    -66.51326044311186
+                ],
+                [
+                    -90.0,
+                    0.0
+                ],
+                [
+                    -180.0,
+                    0.0
+                ],
+                [
+                    -180.0,
+                    -66.51326044311186
+                ],
+                [
+                    -90.0,
+                    -66.51326044311186
+                ]
+            ]
+        ]
+    },
+    "links": [
+        {
+            "rel": "collection",
+            "href": "../collection.json",
+            "type": "application/json",
+            "title": "Global Coastal Transect System Zoom 9"
+        },
+        {
+            "rel": "root",
+            "href": "../../catalog.json",
+            "type": "application/json",
+            "title": "CoCliCo STAC Catalog"
+        },
+        {
+            "rel": "parent",
+            "href": "../collection.json",
+            "type": "application/json",
+            "title": "Global Coastal Transect System Zoom 9"
+        }
+    ],
+    "assets": {
+        "data": {
+            "href": "az://transects/length-2000.parquet/quadkey=qk20/part.11.parquet",
+            "type": "application/x-parquet",
+            "title": "Coastal Transects",
+            "description": "Parquet dataset with the coastal transects for this region.",
+            "roles": [
+                "data"
+            ]
+        }
+    },
+    "bbox": [
+        -179.99979946036342,
+        -44.36481636150471,
+        -90.0205575222102,
+        0.007056207308344007
+    ],
+    "stac_extensions": [
+        "https://stac-extensions.github.io/table/v1.2.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
+    ],
+    "collection": "gcts-2000-z9"
+}

--- a/current/gcts-2000-z9/quadkey=qk21_part.12.parquet/quadkey=qk21_part.12.parquet.json
+++ b/current/gcts-2000-z9/quadkey=qk21_part.12.parquet/quadkey=qk21_part.12.parquet.json
@@ -1,0 +1,119 @@
+{
+    "type": "Feature",
+    "stac_version": "1.0.0",
+    "id": "quadkey=qk21_part.12.parquet",
+    "properties": {
+        "title": "Coastal Transects",
+        "description": "Parquet dataset with the coastal transects",
+        "coclico:quadkey": "21",
+        "table:columns": [
+            {
+                "name": "tr_name",
+                "type": "byte_array",
+                "description": "Building footprint linestrings"
+            },
+            {
+                "name": "lon",
+                "type": "float"
+            },
+            {
+                "name": "lat",
+                "type": "float"
+            },
+            {
+                "name": "bearing",
+                "type": "float"
+            },
+            {
+                "name": "utm_crs",
+                "type": "int32"
+            },
+            {
+                "name": "coastline_name",
+                "type": "int32"
+            },
+            {
+                "name": "geometry",
+                "type": "byte_array"
+            }
+        ],
+        "proj:bbox": [
+            -9991101.504866369,
+            -10019675.144801557,
+            -626559.2741773481,
+            1001.7938369535359
+        ],
+        "proj:epsg": 3857,
+        "table:row_count": 966932,
+        "datetime": "2023-10-27T00:00:00Z"
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    0.0,
+                    -66.51326044311186
+                ],
+                [
+                    0.0,
+                    0.0
+                ],
+                [
+                    -90.0,
+                    0.0
+                ],
+                [
+                    -90.0,
+                    -66.51326044311186
+                ],
+                [
+                    0.0,
+                    -66.51326044311186
+                ]
+            ]
+        ]
+    },
+    "links": [
+        {
+            "rel": "collection",
+            "href": "../collection.json",
+            "type": "application/json",
+            "title": "Global Coastal Transect System Zoom 9"
+        },
+        {
+            "rel": "root",
+            "href": "../../catalog.json",
+            "type": "application/json",
+            "title": "CoCliCo STAC Catalog"
+        },
+        {
+            "rel": "parent",
+            "href": "../collection.json",
+            "type": "application/json",
+            "title": "Global Coastal Transect System Zoom 9"
+        }
+    ],
+    "assets": {
+        "data": {
+            "href": "az://transects/length-2000.parquet/quadkey=qk21/part.12.parquet",
+            "type": "application/x-parquet",
+            "title": "Coastal Transects",
+            "description": "Parquet dataset with the coastal transects for this region.",
+            "roles": [
+                "data"
+            ]
+        }
+    },
+    "bbox": [
+        -89.7515918701101,
+        -66.51655741745773,
+        -5.6284777240034565,
+        0.008999267115719037
+    ],
+    "stac_extensions": [
+        "https://stac-extensions.github.io/table/v1.2.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
+    ],
+    "collection": "gcts-2000-z9"
+}

--- a/current/gcts-2000-z9/quadkey=qk22_part.13.parquet/quadkey=qk22_part.13.parquet.json
+++ b/current/gcts-2000-z9/quadkey=qk22_part.13.parquet/quadkey=qk22_part.13.parquet.json
@@ -1,0 +1,119 @@
+{
+    "type": "Feature",
+    "stac_version": "1.0.0",
+    "id": "quadkey=qk22_part.13.parquet",
+    "properties": {
+        "title": "Coastal Transects",
+        "description": "Parquet dataset with the coastal transects",
+        "coclico:quadkey": "22",
+        "table:columns": [
+            {
+                "name": "tr_name",
+                "type": "byte_array",
+                "description": "Building footprint linestrings"
+            },
+            {
+                "name": "lon",
+                "type": "float"
+            },
+            {
+                "name": "lat",
+                "type": "float"
+            },
+            {
+                "name": "bearing",
+                "type": "float"
+            },
+            {
+                "name": "utm_crs",
+                "type": "int32"
+            },
+            {
+                "name": "coastline_name",
+                "type": "int32"
+            },
+            {
+                "name": "geometry",
+                "type": "byte_array"
+            }
+        ],
+        "proj:bbox": [
+            -20036971.317569632,
+            -14781714.247650128,
+            -10018047.875686485,
+            -10673538.056648372
+        ],
+        "proj:epsg": 3857,
+        "table:row_count": 54228,
+        "datetime": "2023-10-27T00:00:00Z"
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    -90.0,
+                    -85.0511287798066
+                ],
+                [
+                    -90.0,
+                    -66.51326044311186
+                ],
+                [
+                    -180.0,
+                    -66.51326044311186
+                ],
+                [
+                    -180.0,
+                    -85.0511287798066
+                ],
+                [
+                    -90.0,
+                    -85.0511287798066
+                ]
+            ]
+        ]
+    },
+    "links": [
+        {
+            "rel": "collection",
+            "href": "../collection.json",
+            "type": "application/json",
+            "title": "Global Coastal Transect System Zoom 9"
+        },
+        {
+            "rel": "root",
+            "href": "../../catalog.json",
+            "type": "application/json",
+            "title": "CoCliCo STAC Catalog"
+        },
+        {
+            "rel": "parent",
+            "href": "../collection.json",
+            "type": "application/json",
+            "title": "Global Coastal Transect System Zoom 9"
+        }
+    ],
+    "assets": {
+        "data": {
+            "href": "az://transects/length-2000.parquet/quadkey=qk22/part.13.parquet",
+            "type": "application/x-parquet",
+            "title": "Coastal Transects",
+            "description": "Parquet dataset with the coastal transects for this region.",
+            "roles": [
+                "data"
+            ]
+        }
+    },
+    "bbox": [
+        -179.99517582037265,
+        -78.74747176732404,
+        -89.99365523770273,
+        -68.74990551986006
+    ],
+    "stac_extensions": [
+        "https://stac-extensions.github.io/table/v1.2.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
+    ],
+    "collection": "gcts-2000-z9"
+}

--- a/current/gcts-2000-z9/quadkey=qk23_part.14.parquet/quadkey=qk23_part.14.parquet.json
+++ b/current/gcts-2000-z9/quadkey=qk23_part.14.parquet/quadkey=qk23_part.14.parquet.json
@@ -1,0 +1,119 @@
+{
+    "type": "Feature",
+    "stac_version": "1.0.0",
+    "id": "quadkey=qk23_part.14.parquet",
+    "properties": {
+        "title": "Coastal Transects",
+        "description": "Parquet dataset with the coastal transects",
+        "coclico:quadkey": "23",
+        "table:columns": [
+            {
+                "name": "tr_name",
+                "type": "byte_array",
+                "description": "Building footprint linestrings"
+            },
+            {
+                "name": "lon",
+                "type": "float"
+            },
+            {
+                "name": "lat",
+                "type": "float"
+            },
+            {
+                "name": "bearing",
+                "type": "float"
+            },
+            {
+                "name": "utm_crs",
+                "type": "int32"
+            },
+            {
+                "name": "coastline_name",
+                "type": "int32"
+            },
+            {
+                "name": "geometry",
+                "type": "byte_array"
+            }
+        ],
+        "proj:bbox": [
+            -10018474.224187942,
+            -14447028.129021699,
+            -70.63115693983954,
+            -10017603.73597465
+        ],
+        "proj:epsg": 3857,
+        "table:row_count": 102877,
+        "datetime": "2023-10-27T00:00:00Z"
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    0.0,
+                    -85.0511287798066
+                ],
+                [
+                    0.0,
+                    -66.51326044311186
+                ],
+                [
+                    -90.0,
+                    -66.51326044311186
+                ],
+                [
+                    -90.0,
+                    -85.0511287798066
+                ],
+                [
+                    0.0,
+                    -85.0511287798066
+                ]
+            ]
+        ]
+    },
+    "links": [
+        {
+            "rel": "collection",
+            "href": "../collection.json",
+            "type": "application/json",
+            "title": "Global Coastal Transect System Zoom 9"
+        },
+        {
+            "rel": "root",
+            "href": "../../catalog.json",
+            "type": "application/json",
+            "title": "CoCliCo STAC Catalog"
+        },
+        {
+            "rel": "parent",
+            "href": "../collection.json",
+            "type": "application/json",
+            "title": "Global Coastal Transect System Zoom 9"
+        }
+    ],
+    "assets": {
+        "data": {
+            "href": "az://transects/length-2000.parquet/quadkey=qk23/part.14.parquet",
+            "type": "application/x-parquet",
+            "title": "Coastal Transects",
+            "description": "Parquet dataset with the coastal transects for this region.",
+            "roles": [
+                "data"
+            ]
+        }
+    },
+    "bbox": [
+        -89.99748519145493,
+        -78.14544733177543,
+        -0.0006344904781410246,
+        -66.50914140887406
+    ],
+    "stac_extensions": [
+        "https://stac-extensions.github.io/table/v1.2.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
+    ],
+    "collection": "gcts-2000-z9"
+}

--- a/current/gcts-2000-z9/quadkey=qk30_part.15.parquet/quadkey=qk30_part.15.parquet.json
+++ b/current/gcts-2000-z9/quadkey=qk30_part.15.parquet/quadkey=qk30_part.15.parquet.json
@@ -1,0 +1,119 @@
+{
+    "type": "Feature",
+    "stac_version": "1.0.0",
+    "id": "quadkey=qk30_part.15.parquet",
+    "properties": {
+        "title": "Coastal Transects",
+        "description": "Parquet dataset with the coastal transects",
+        "coclico:quadkey": "30",
+        "table:columns": [
+            {
+                "name": "tr_name",
+                "type": "byte_array",
+                "description": "Building footprint linestrings"
+            },
+            {
+                "name": "lon",
+                "type": "float"
+            },
+            {
+                "name": "lat",
+                "type": "float"
+            },
+            {
+                "name": "bearing",
+                "type": "float"
+            },
+            {
+                "name": "utm_crs",
+                "type": "int32"
+            },
+            {
+                "name": "coastline_name",
+                "type": "int32"
+            },
+            {
+                "name": "geometry",
+                "type": "byte_array"
+            }
+        ],
+        "proj:bbox": [
+            364206.73805778247,
+            -10020818.11582478,
+            9786202.019324807,
+            587.9839414474061
+        ],
+        "proj:epsg": 3857,
+        "table:row_count": 255032,
+        "datetime": "2023-10-27T00:00:00Z"
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    90.0,
+                    -66.51326044311186
+                ],
+                [
+                    90.0,
+                    0.0
+                ],
+                [
+                    0.0,
+                    0.0
+                ],
+                [
+                    0.0,
+                    -66.51326044311186
+                ],
+                [
+                    90.0,
+                    -66.51326044311186
+                ]
+            ]
+        ]
+    },
+    "links": [
+        {
+            "rel": "collection",
+            "href": "../collection.json",
+            "type": "application/json",
+            "title": "Global Coastal Transect System Zoom 9"
+        },
+        {
+            "rel": "root",
+            "href": "../../catalog.json",
+            "type": "application/json",
+            "title": "CoCliCo STAC Catalog"
+        },
+        {
+            "rel": "parent",
+            "href": "../collection.json",
+            "type": "application/json",
+            "title": "Global Coastal Transect System Zoom 9"
+        }
+    ],
+    "assets": {
+        "data": {
+            "href": "az://transects/length-2000.parquet/quadkey=qk30/part.15.parquet",
+            "type": "application/x-parquet",
+            "title": "Coastal Transects",
+            "description": "Parquet dataset with the coastal transects for this region.",
+            "roles": [
+                "data"
+            ]
+        }
+    },
+    "bbox": [
+        3.2717247937662095,
+        -66.52064850949372,
+        87.91094847440799,
+        0.005281949606708968
+    ],
+    "stac_extensions": [
+        "https://stac-extensions.github.io/table/v1.2.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
+    ],
+    "collection": "gcts-2000-z9"
+}

--- a/current/gcts-2000-z9/quadkey=qk31_part.16.parquet/quadkey=qk31_part.16.parquet.json
+++ b/current/gcts-2000-z9/quadkey=qk31_part.16.parquet/quadkey=qk31_part.16.parquet.json
@@ -1,0 +1,119 @@
+{
+    "type": "Feature",
+    "stac_version": "1.0.0",
+    "id": "quadkey=qk31_part.16.parquet",
+    "properties": {
+        "title": "Coastal Transects",
+        "description": "Parquet dataset with the coastal transects",
+        "coclico:quadkey": "31",
+        "table:columns": [
+            {
+                "name": "tr_name",
+                "type": "byte_array",
+                "description": "Building footprint linestrings"
+            },
+            {
+                "name": "lon",
+                "type": "float"
+            },
+            {
+                "name": "lat",
+                "type": "float"
+            },
+            {
+                "name": "bearing",
+                "type": "float"
+            },
+            {
+                "name": "utm_crs",
+                "type": "int32"
+            },
+            {
+                "name": "coastline_name",
+                "type": "int32"
+            },
+            {
+                "name": "geometry",
+                "type": "byte_array"
+            }
+        ],
+        "proj:bbox": [
+            10265210.123796193,
+            -10021102.219434936,
+            20037494.075439192,
+            905.1886098437911
+        ],
+        "proj:epsg": 3857,
+        "table:row_count": 1460836,
+        "datetime": "2023-10-27T00:00:00Z"
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    180.0,
+                    -66.51326044311186
+                ],
+                [
+                    180.0,
+                    0.0
+                ],
+                [
+                    90.0,
+                    0.0
+                ],
+                [
+                    90.0,
+                    -66.51326044311186
+                ],
+                [
+                    180.0,
+                    -66.51326044311186
+                ]
+            ]
+        ]
+    },
+    "links": [
+        {
+            "rel": "collection",
+            "href": "../collection.json",
+            "type": "application/json",
+            "title": "Global Coastal Transect System Zoom 9"
+        },
+        {
+            "rel": "root",
+            "href": "../../catalog.json",
+            "type": "application/json",
+            "title": "CoCliCo STAC Catalog"
+        },
+        {
+            "rel": "parent",
+            "href": "../collection.json",
+            "type": "application/json",
+            "title": "Global Coastal Transect System Zoom 9"
+        }
+    ],
+    "assets": {
+        "data": {
+            "href": "az://transects/length-2000.parquet/quadkey=qk31/part.16.parquet",
+            "type": "application/x-parquet",
+            "title": "Coastal Transects",
+            "description": "Parquet dataset with the coastal transects for this region.",
+            "roles": [
+                "data"
+            ]
+        }
+    },
+    "bbox": [
+        92.21395148904566,
+        -66.52166531108922,
+        179.99987183421385,
+        0.00813144760503929
+    ],
+    "stac_extensions": [
+        "https://stac-extensions.github.io/table/v1.2.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
+    ],
+    "collection": "gcts-2000-z9"
+}

--- a/current/gcts-2000-z9/quadkey=qk32_part.17.parquet/quadkey=qk32_part.17.parquet.json
+++ b/current/gcts-2000-z9/quadkey=qk32_part.17.parquet/quadkey=qk32_part.17.parquet.json
@@ -1,0 +1,119 @@
+{
+    "type": "Feature",
+    "stac_version": "1.0.0",
+    "id": "quadkey=qk32_part.17.parquet",
+    "properties": {
+        "title": "Coastal Transects",
+        "description": "Parquet dataset with the coastal transects",
+        "coclico:quadkey": "32",
+        "table:columns": [
+            {
+                "name": "tr_name",
+                "type": "byte_array",
+                "description": "Building footprint linestrings"
+            },
+            {
+                "name": "lon",
+                "type": "float"
+            },
+            {
+                "name": "lat",
+                "type": "float"
+            },
+            {
+                "name": "bearing",
+                "type": "float"
+            },
+            {
+                "name": "utm_crs",
+                "type": "int32"
+            },
+            {
+                "name": "coastline_name",
+                "type": "int32"
+            },
+            {
+                "name": "geometry",
+                "type": "byte_array"
+            }
+        ],
+        "proj:bbox": [
+            356.1966673375465,
+            -11183676.547165848,
+            10019628.611691229,
+            -10016651.890017409
+        ],
+        "proj:epsg": 3857,
+        "table:row_count": 80407,
+        "datetime": "2023-10-27T00:00:00Z"
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    90.0,
+                    -85.0511287798066
+                ],
+                [
+                    90.0,
+                    -66.51326044311186
+                ],
+                [
+                    0.0,
+                    -66.51326044311186
+                ],
+                [
+                    0.0,
+                    -85.0511287798066
+                ],
+                [
+                    90.0,
+                    -85.0511287798066
+                ]
+            ]
+        ]
+    },
+    "links": [
+        {
+            "rel": "collection",
+            "href": "../collection.json",
+            "type": "application/json",
+            "title": "Global Coastal Transect System Zoom 9"
+        },
+        {
+            "rel": "root",
+            "href": "../../catalog.json",
+            "type": "application/json",
+            "title": "CoCliCo STAC Catalog"
+        },
+        {
+            "rel": "parent",
+            "href": "../collection.json",
+            "type": "application/json",
+            "title": "Global Coastal Transect System Zoom 9"
+        }
+    ],
+    "assets": {
+        "data": {
+            "href": "az://transects/length-2000.parquet/quadkey=qk32/part.17.parquet",
+            "type": "application/x-parquet",
+            "title": "Coastal Transects",
+            "description": "Parquet dataset with the coastal transects for this region.",
+            "roles": [
+                "data"
+            ]
+        }
+    },
+    "bbox": [
+        0.0031997691042175472,
+        -70.35023148643705,
+        90.00785523083492,
+        -66.50573289184041
+    ],
+    "stac_extensions": [
+        "https://stac-extensions.github.io/table/v1.2.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
+    ],
+    "collection": "gcts-2000-z9"
+}

--- a/current/gcts-2000-z9/quadkey=qk33_part.18.parquet/quadkey=qk33_part.18.parquet.json
+++ b/current/gcts-2000-z9/quadkey=qk33_part.18.parquet/quadkey=qk33_part.18.parquet.json
@@ -1,0 +1,119 @@
+{
+    "type": "Feature",
+    "stac_version": "1.0.0",
+    "id": "quadkey=qk33_part.18.parquet",
+    "properties": {
+        "title": "Coastal Transects",
+        "description": "Parquet dataset with the coastal transects",
+        "coclico:quadkey": "33",
+        "table:columns": [
+            {
+                "name": "tr_name",
+                "type": "byte_array",
+                "description": "Building footprint linestrings"
+            },
+            {
+                "name": "lon",
+                "type": "float"
+            },
+            {
+                "name": "lat",
+                "type": "float"
+            },
+            {
+                "name": "bearing",
+                "type": "float"
+            },
+            {
+                "name": "utm_crs",
+                "type": "int32"
+            },
+            {
+                "name": "coastline_name",
+                "type": "int32"
+            },
+            {
+                "name": "geometry",
+                "type": "byte_array"
+            }
+        ],
+        "proj:bbox": [
+            10018145.112677164,
+            -14383667.450571856,
+            20037236.06911872,
+            -10016383.548736647
+        ],
+        "proj:epsg": 3857,
+        "table:row_count": 73836,
+        "datetime": "2023-10-27T00:00:00Z"
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    180.0,
+                    -85.0511287798066
+                ],
+                [
+                    180.0,
+                    -66.51326044311186
+                ],
+                [
+                    90.0,
+                    -66.51326044311186
+                ],
+                [
+                    90.0,
+                    -85.0511287798066
+                ],
+                [
+                    180.0,
+                    -85.0511287798066
+                ]
+            ]
+        ]
+    },
+    "links": [
+        {
+            "rel": "collection",
+            "href": "../collection.json",
+            "type": "application/json",
+            "title": "Global Coastal Transect System Zoom 9"
+        },
+        {
+            "rel": "root",
+            "href": "../../catalog.json",
+            "type": "application/json",
+            "title": "CoCliCo STAC Catalog"
+        },
+        {
+            "rel": "parent",
+            "href": "../collection.json",
+            "type": "application/json",
+            "title": "Global Coastal Transect System Zoom 9"
+        }
+    ],
+    "assets": {
+        "data": {
+            "href": "az://transects/length-2000.parquet/quadkey=qk33/part.18.parquet",
+            "type": "application/x-parquet",
+            "title": "Coastal Transects",
+            "description": "Parquet dataset with the coastal transects for this region.",
+            "roles": [
+                "data"
+            ]
+        }
+    },
+    "bbox": [
+        89.99452873245181,
+        -78.02795197227032,
+        179.99755412400305,
+        -66.50477188963279
+    ],
+    "stac_extensions": [
+        "https://stac-extensions.github.io/table/v1.2.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
+    ],
+    "collection": "gcts-2000-z9"
+}


### PR DESCRIPTION
Added transects dataset (GCTS9) to CoCliCo STAC. The STAC describes the 22 parquet partitions. The transects are stored at an Azure cloud bucket, that is private, until publication is accepted. If you want to access the data ask Floris Calkoen for keys. Likewise, the scripts for data processing can also be asked from him. 

